### PR TITLE
[ci skip] [skip ci] [cf admin skip] ***NO_CI*** Merge main including admin migration CondaForgeMasterToMain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bouweandela @nielsdrost @schlunma @valeriupredoi @zklaus
+* @sloosvel @bouweandela @nielsdrost @schlunma @valeriupredoi @zklaus

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sloosvel @bouweandela @nielsdrost @schlunma @valeriupredoi @zklaus
+* @bouweandela @nielsdrost @schlunma @sloosvel @valeriupredoi @zklaus

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: automerge-action
         id: automerge-action
-        uses: conda-forge/automerge-action@master
+        uses: conda-forge/automerge-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: webservices
         id: webservices
-        uses: conda-forge/webservices-dispatch-action@master
+        uses: conda-forge/webservices-dispatch-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           rerendering_github_token: ${{ secrets.RERENDERING_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Feedstock Maintainers
 * [@bouweandela](https://github.com/bouweandela/)
 * [@nielsdrost](https://github.com/nielsdrost/)
 * [@schlunma](https://github.com/schlunma/)
+* [@sloosvel](https://github.com/sloosvel/)
 * [@valeriupredoi](https://github.com/valeriupredoi/)
 * [@zklaus](https://github.com/zklaus/)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://www.esmvaltool.org
 
 Package license: Apache-2.0
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/esmvalcore-feedstock/blob/master/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/esmvalcore-feedstock/blob/main/LICENSE.txt)
 
 Summary: ESMValCore: A community tool for pre-processing data from Earth system models in CMIP and running analysis scripts.
 
@@ -21,8 +21,8 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12350&branchName=master">
-        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/esmvalcore-feedstock?branchName=master">
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=12350&branchName=main">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/esmvalcore-feedstock?branchName=main">
       </a>
     </td>
   </tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,4 @@
 conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,8 +89,11 @@ test:
     - esmvalcore.cmor
     - esmvalcore.cmor.check
     - esmvalcore.cmor.fix
-    - esmvalcore.preprocessor
+    - esmvalcore.esgf
+    - esmvalcore.exceptions
     - esmvalcore.experimental
+    - esmvalcore.iris_helpers
+    - esmvalcore.preprocessor
 
 about:
   home: https://www.esmvaltool.org
@@ -106,5 +109,6 @@ extra:
     - bouweandela
     - nielsdrost
     - schlunma
+    - sloosvel
     - valeriupredoi
     - zklaus


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] ~Bumped the build number (if the version is unchanged)~
* [x] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is an attempt to merge `main` back into `rc`. This should add @sloosvel to the maintainers also here and it switches us over to the `main` branch of the conda-forge tooling. This happened automatically for our own `main` branch via the bot in fa40e87dba843d14a1aceb8ef666aa330e7ba531, but was still missing in `rc`.

Since this is changing only CODEOWNERS and README, we don't need to build again, so I'll skip the CI via tags in the title.