### PR TITLE
unpin netcdf4 to free and bump build number to 1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   # Increment the build number when building a new conda package of the same
   # esmvalcore version, reset to 0 when building a new version.
-  number: 0
+  number: 1
   # This is noarch but will fail on windows due to missing dependency esmpy.
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
@@ -46,7 +46,7 @@ requirements:
     - jinja2
     - nc-time-axis
     - nested-lookup
-    - netCDF4 !=1.6.1
+    - netCDF4
     - numpy
     - pandas
     - pillow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     # Normally installed via pip:
     - cartopy
     - cftime
-    - cf-units >=3.0.0, <3.1.0, !=3.0.1.post0
+    - cf-units
     - dask
     - esgf-pyclient >=0.3.1
     - esmpy !=8.1.0
@@ -64,7 +64,7 @@ test:
     - setup.cfg
   requires:
     # - ESMValTool_sample_data==0.0.3
-    - flake8 <5.0
+    - flake8
     - pip
     - pytest
     - pytest-cov
@@ -73,7 +73,7 @@ test:
     - pytest-html
     - pytest-metadata
     - pytest-mock
-    - pytest-mypy
+    - pytest-mypy <0.10.1
     - pytest-xdist
     - r-yaml
     # - types-requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ test:
   requires:
     # - ESMValTool_sample_data==0.0.3
     - flake8
-    - mypy <0.99
+    - mypy <0.990
     - pip
     - pytest
     - pytest-cov

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,7 @@ test:
     - pytest-html
     - pytest-metadata
     - pytest-mock
-    - pytest-mypy <0.10.1
+    - pytest-mypy
     - pytest-xdist
     - r-yaml
     # - types-requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,6 +65,7 @@ test:
   requires:
     # - ESMValTool_sample_data==0.0.3
     - flake8
+    - mypy <0.99
     - pip
     - pytest
     - pytest-cov

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     # Normally installed via pip:
     - cartopy
     - cftime
-    - cf-units
+    - cf-units >=3.0.0, <3.1.0, !=3.0.1.post0
     - dask
     - esgf-pyclient >=0.3.1
     - esmpy !=8.1.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

We repo patched iris to force the pin netCDF4<1.6.1 across versions, so our pin is now redundant. We have done the same in the dev repo https://github.com/ESMValGroup/ESMValCore/pull/1814

To be able to have the tests run and package be built I had to pin mypy plugin, I also released the pin on flake8 as we did in Core just recently.